### PR TITLE
fix: Swagger doesn't support BigInt

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,4 +1,6 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { parseEther } from 'viem';
+
 import { AppService } from './app.service';
 import { MintTokenDto } from './dtos/mintToken.dto';
 
@@ -45,7 +47,10 @@ export class AppController {
   @Post('mint-tokens')
   async mintTokens(@Body() body: MintTokenDto) {
     return {
-      result: this.appService.mintTokens(body.address, body.amountToMint),
+      result: this.appService.mintTokens(
+        body.address,
+        parseEther(body.amountToMint),
+      ),
     };
   }
 }

--- a/backend/src/dtos/mintToken.dto.ts
+++ b/backend/src/dtos/mintToken.dto.ts
@@ -1,10 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { parseEther } from 'viem';
 
 export class MintTokenDto {
   @ApiProperty({ type: String, required: true, default: 'My Address' })
   address: `0x${string}`;
 
-  @ApiProperty({ type: Number, required: true, default: parseEther('100') })
-  amountToMint: bigint;
+  @ApiProperty({ type: Number, required: true, default: 1 })
+  amountToMint: number;
 }


### PR DESCRIPTION
JSON.striginfy cannot serialize BigInt
```
[Nest] 14387  - 04/07/2024, 4:38:00 PM    WARN [ExpressAdapter] Content-Type doesn't match Reply body, you might need a custom ExceptionFilter for non-JSON responses
[Nest] 14387  - 04/07/2024, 4:38:00 PM   ERROR [ExceptionsHandler] Do not know how to serialize a BigInt
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
```