### PR TITLE
revert: tailwind theme

### DIFF
--- a/frontend/packages/nextjs/tailwind.config.js
+++ b/frontend/packages/nextjs/tailwind.config.js
@@ -1,74 +1,74 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./app/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}', './utils/**/*.{js,ts,jsx,tsx}'],
-  plugins: [require('daisyui')],
-  darkTheme: 'dark',
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}", "./utils/**/*.{js,ts,jsx,tsx}"],
+  plugins: [require("daisyui")],
+  darkTheme: "dark",
   // DaisyUI theme colors
   daisyui: {
     themes: [
       {
         light: {
-          primary: '#a15e61',
-          'primary-content': '#ffffff',
-          secondary: '#DAE8FF',
-          'secondary-content': '#212638',
-          accent: '#93BBFB',
-          'accent-content': '#212638',
-          neutral: '#212638',
-          'neutral-content': '#ffffff',
-          'base-100': '#ffffff',
-          'base-200': '#f5ebe0',
-          'base-300': '#DAE8FF',
-          'base-content': '#212638',
-          info: '#93BBFB',
-          success: '#34EEB6',
-          warning: '#FFCF72',
-          error: '#FF8863',
+          primary: "#93BBFB",
+          "primary-content": "#212638",
+          secondary: "#DAE8FF",
+          "secondary-content": "#212638",
+          accent: "#93BBFB",
+          "accent-content": "#212638",
+          neutral: "#212638",
+          "neutral-content": "#ffffff",
+          "base-100": "#ffffff",
+          "base-200": "#f4f8ff",
+          "base-300": "#DAE8FF",
+          "base-content": "#212638",
+          info: "#93BBFB",
+          success: "#34EEB6",
+          warning: "#FFCF72",
+          error: "#FF8863",
 
-          '--rounded-btn': '9999rem',
+          "--rounded-btn": "9999rem",
 
-          '.tooltip': {
-            '--tooltip-tail': '6px',
+          ".tooltip": {
+            "--tooltip-tail": "6px",
           },
-          '.link': {
-            textUnderlineOffset: '2px',
+          ".link": {
+            textUnderlineOffset: "2px",
           },
-          '.link:hover': {
-            opacity: '80%',
+          ".link:hover": {
+            opacity: "80%",
           },
         },
       },
       {
         dark: {
-          primary: '#212638',
-          'primary-content': '#F9FBFF',
-          secondary: '#323f61',
-          'secondary-content': '#F9FBFF',
-          accent: '#4969A6',
-          'accent-content': '#F9FBFF',
-          neutral: '#F9FBFF',
-          'neutral-content': '#385183',
-          'base-100': '#385183',
-          'base-200': '#2A3655',
-          'base-300': '#212638',
-          'base-content': '#F9FBFF',
-          'expansion': '#f7c631',
-          info: '#385183',
-          success: '#34EEB6',
-          warning: '#FFCF72',
-          error: '#FF8863',
+          primary: "#212638",
+          "primary-content": "#F9FBFF",
+          secondary: "#323f61",
+          "secondary-content": "#F9FBFF",
+          accent: "#4969A6",
+          "accent-content": "#F9FBFF",
+          neutral: "#F9FBFF",
+          "neutral-content": "#385183",
+          "base-100": "#385183",
+          "base-200": "#2A3655",
+          "base-300": "#212638",
+          "base-content": "#F9FBFF",
+          "expansion": "#f7c631",
+          info: "#385183",
+          success: "#34EEB6",
+          warning: "#FFCF72",
+          error: "#FF8863",
 
-          '--rounded-btn': '9999rem',
+          "--rounded-btn": "9999rem",
 
-          '.tooltip': {
-            '--tooltip-tail': '6px',
-            '--tooltip-color': 'oklch(var(--p))',
+          ".tooltip": {
+            "--tooltip-tail": "6px",
+            "--tooltip-color": "oklch(var(--p))",
           },
-          '.link': {
-            textUnderlineOffset: '2px',
+          ".link": {
+            textUnderlineOffset: "2px",
           },
-          '.link:hover': {
-            opacity: '80%',
+          ".link:hover": {
+            opacity: "80%",
           },
         },
       },
@@ -77,10 +77,10 @@ module.exports = {
   theme: {
     extend: {
       boxShadow: {
-        center: '0 0 12px -2px rgb(0 0 0 / 0.05)',
+        center: "0 0 12px -2px rgb(0 0 0 / 0.05)",
       },
       animation: {
-        'pulse-fast': 'pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+        "pulse-fast": "pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite",
       },
     },
   },


### PR DESCRIPTION
@Spacylion I've reverted theme, because it requires more tuning
For example, the input text in light theme isn't visible

<img width="403" alt="Screenshot 2024-04-07 at 20 29 51" src="https://github.com/ZK-solidity-army/week4_lesson/assets/601863/41adf405-23fb-415f-bbfd-f71c4429c5a9">
